### PR TITLE
Add support for other GitHub user packages - not just self-owned

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:0-1.20-bullseye",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"streetsidesoftware.code-spell-checker"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [10000]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 container-registry-proxy
+notes.txt
+app


### PR DESCRIPTION
You can supply a GITHUB_USERS environment variable that contains a comma delimited list of GitHub users.
Ex: export GITHUB_USERS="blakeblackshear,someotherusername"

By doing so not only will container registry proxy list the packages from your own GitHub account, but also the packages available in the other user accounts.

I have provided an updated Docker image for testing
hedrickbt/container-registry-proxy
https://hub.docker.com/repository/docker/hedrickbt/container-registry-proxy/general

TESTS
Multiple users, but one is a duplicate
`export GITHUB_USERS="blakeblackshear,blakeblackshear"

2024/02/17 18:06:52 starting container registry proxy on 127.0.0.1:10000
2024/02/17 18:06:57 Catalog Request GET -> /v2/_catalog
2024/02/17 18:06:57 GitHub Users ,blakeblackshear,blakeblackshear
2024/02/17 18:06:57 ListPackages for "" found 0 _new_ packages
2024/02/17 18:06:57 ListPackages for "blakeblackshear" found 1 _new_ packages
2024/02/17 18:06:58 ListPackages for "blakeblackshear" found 0 _new_ packages
`

If you don't export GITHUB_USERS, it will only do the default, self, packages
unset GITHUB_USERS
`
2024/02/17 18:12:23 starting container registry proxy on 127.0.0.1:10000
2024/02/17 18:12:29 Catalog Request GET -> /v2/_catalog
2024/02/17 18:12:29 GitHub Users 
2024/02/17 18:12:29 ListPackages for "" found 0 _new_ packages
`
If at least 1 username does not get an error for the package list, , it will be returned to synology
`
export GITHUB_USERS="blakeblackshear2,blakeblackshear"
2024/02/17 18:18:04 starting container registry proxy on 127.0.0.1:10000
2024/02/17 18:18:20 Catalog Request GET -> /v2/_catalog
2024/02/17 18:18:20 GitHub Users ,blakeblackshear2,blakeblackshear
2024/02/17 18:18:20 ListPackages for "" found 0 _new_ packages
2024/02/17 18:18:20 WARN ListPackages for "blakeblackshear2" error: GET https://api.github.com/users/blakeblackshear2/packages?package_type=container: 404 Not Found []
2024/02/17 18:18:21 ListPackages for "blakeblackshear" found 1 _new_ packages
`

If every single username, including the default user "", fails a generic error will be shown by Synology.  Ex invalid github token.
`
2024/02/17 18:21:27 starting container registry proxy on 127.0.0.1:10000
2024/02/17 18:21:33 Catalog Request GET -> /v2/_catalog
2024/02/17 18:21:33 GitHub Users ,blakeblackshear2,blakeblackshear2
2024/02/17 18:21:33 WARN ListPackages for "" error: GET https://api.github.com/user/packages?package_type=container: 401 Bad credentials []
2024/02/17 18:21:33 WARN ListPackages for "blakeblackshear2" error: GET https://api.github.com/users/blakeblackshear2/packages?package_type=container: 401 Bad credentials []
2024/02/17 18:21:34 WARN ListPackages for "blakeblackshear2" error: GET https://api.github.com/users/blakeblackshear2/packages?package_type=container: 401 Bad credentials []
2024/02/17 18:21:34 Not Found GET /v1/search?q=library/&n=50&page=1 -> https://ghcr.io
`
